### PR TITLE
4.3.2

### DIFF
--- a/Slackord/Classes/DiscordBot.cs
+++ b/Slackord/Classes/DiscordBot.cs
@@ -278,7 +278,7 @@ namespace Slackord.Classes
 
                             if (message.ThreadType == ThreadType.Parent)
                             {
-                                string threadName = message.Message.Length <= 20 ? message.Message : message.Message[..20];
+                                string threadName = string.IsNullOrEmpty(message.Message) ? "Replies" : message.Message.Length <= 20 ? message.Message : message.Message[..20];
                                 await webhookClient.SendMessageAsync(message.Content, false, null, message.User, message.Avatar);
                                 IEnumerable<RestMessage> threadMessages = await discordChannel.GetMessagesAsync(1).FlattenAsync();
                                 RestThreadChannel threadID = await discordChannel.CreateThreadAsync(threadName, Discord.ThreadType.PublicThread, ThreadArchiveDuration.OneDay, threadMessages.First());

--- a/Slackord/Classes/DiscordBot.cs
+++ b/Slackord/Classes/DiscordBot.cs
@@ -17,7 +17,7 @@ namespace Slackord.Classes
         private DiscordBot() { }
         private CancellationTokenSource _cancellationTokenSource;
 
-        public async Task StartClientAsync()
+        public async Task StartClientAsync(string discordToken)
         {
             bool isConnected = false;
             int maxRetryAttempts = 3;
@@ -27,6 +27,10 @@ namespace Slackord.Classes
             {
                 try
                 {
+                    if (DiscordClient.LoginState != LoginState.LoggedIn)
+                    {
+                        await DiscordClient.LoginAsync(TokenType.Bot, discordToken.Trim());
+                    }
                     await DiscordClient.StartAsync();
                     isConnected = true;
                     break;
@@ -49,14 +53,21 @@ namespace Slackord.Classes
             }
         }
 
-        public async Task StopClientAsync()
+        public async Task LogoutClientAsync()
         {
-            await DiscordClient.StopAsync();
+            try
+            {
+                await DiscordClient.LogoutAsync();
+            }
+            catch (Exception ex)
+            {
+                ApplicationWindow.WriteToDebugWindow($"Error while stopping the Discord client: {ex.Message}");
+            }
         }
 
         public ConnectionState GetClientConnectionState()
         {
-            return DiscordClient.ConnectionState;
+            return DiscordClient?.ConnectionState ?? ConnectionState.Disconnected;
         }
 
         private Task DiscordClient_Log(LogMessage arg)

--- a/Slackord/Classes/ImportJson.cs
+++ b/Slackord/Classes/ImportJson.cs
@@ -26,8 +26,18 @@ namespace Slackord.Classes
                 // Check if picker is null or if its Folder property is null.
                 if (picker == null || picker.Folder == null)
                 {
-                    _ = Application.Current.Dispatcher.Dispatch(() => { ApplicationWindow.WriteToDebugWindow($"Exception(1000) in FolderPicker : Import canceled by user.\nDue to platform requirements, Slackord must be restarted when you cancel the folder browser.\nCurrently, there's no workaround. Sorry about this!\n"); });
-                    return;
+                    // Check if the cancellation was requested
+                    if (cancellationToken.IsCancellationRequested)
+                    {
+                        // Log the cancellation message
+                        _ = Application.Current.Dispatcher.Dispatch(() => { ApplicationWindow.WriteToDebugWindow("Folder selection was cancelled.\n"); });
+                        return;
+                    }
+                    else
+                    {
+                        // Import was cancelled
+                        return;
+                    }
                 }
 
                 string folderPath = picker.Folder.Path;
@@ -58,6 +68,11 @@ namespace Slackord.Classes
                         });
                     }
                 }
+            }
+            catch (OperationCanceledException)
+            {
+                // Handle the cancellation exception
+                _ = Application.Current.Dispatcher.Dispatch(() => { ApplicationWindow.WriteToDebugWindow("Import operation was cancelled.\n"); });
             }
             catch (Exception ex)
             {

--- a/Slackord/Classes/UpdateCheck.cs
+++ b/Slackord/Classes/UpdateCheck.cs
@@ -10,11 +10,10 @@ namespace Slackord.Classes
         public static async Task CheckForUpdates()
         {
             string _currentVersion = Version.GetVersion();
-
             _octoClient = new GitHubClient(new ProductHeaderValue("Slackord"));
-
             IReadOnlyList<Release> releases = await _octoClient.Repository.Release.GetAll("thomasloupe", "Slackord");
             Release latest = releases[0];
+
             if (_currentVersion == latest.TagName)
             {
                 await Microsoft.Maui.Controls.Application.Current.MainPage.DisplayAlert(_currentVersion, "You have the latest version, " + _currentVersion + "!", "OK");
@@ -24,20 +23,29 @@ namespace Slackord.Classes
                 MainThread.BeginInvokeOnMainThread(() =>
                 {
                     MainPage.DebugWindowInstance.Text += $"""
+                    Your Slackord version is out of date.
+                    Current Version: {_currentVersion}
+                    Latest Version: {latest.TagName}
+                    
+                    Release Notes:
+                    {latest.Body}
 
-                Your Slackord version is out of date.
-                Current Version: {_currentVersion}
-                Latest Version: {latest.TagName}
-                Please consider upgrading at https://github.com/thomasloupe/Slackord/release/{latest.TagName}.
-
-                """;
+                    Please consider upgrading at https://github.com/thomasloupe/Slackord/release/{latest.TagName}.
+                    
+                    """;
                 });
 
-                bool result = await Microsoft.Maui.Controls.Application.Current.MainPage.DisplayAlert("Update Available!",
-                    "A new version of Slackord is available!" + "\n" +
-                    $"Current version: {_currentVersion}" + "\n" +
-                    $"Latest version: {latest.TagName}" + "\n" +
-                    "Would you like to visit the download page?",
+                bool result = await Microsoft.Maui.Controls.Application.Current.MainPage.DisplayAlert("Slackord Update Available!",
+                    $@"A new version of Slackord is available!
+Current version: {_currentVersion}
+Latest version: {latest.TagName}
+    
+You are missing the following features and bug fixes:
+
+{latest.Body}
+
+It is highly recommended that you always have the latest version available.    
+Would you like to visit the download page?",
                     "Yes", "No");
 
                 if (result)

--- a/Slackord/Classes/Version.cs
+++ b/Slackord/Classes/Version.cs
@@ -4,7 +4,7 @@
     {
         public static string GetVersion()
         {
-            string version = "v4.3.1";
+            string version = "v4.3.2";
 
             return version;
         }

--- a/Slackord/MainPage.xaml.cs
+++ b/Slackord/MainPage.xaml.cs
@@ -45,6 +45,7 @@ namespace MenuApp
         private async Task Initialize()
         {
             applicationWindow.CheckForFirstRun();
+            await ApplicationWindow.CheckForNewVersion();
             await applicationWindow.CheckForValidBotToken();
             await ApplicationWindow.GetTimeStampValue();
             await ApplicationWindow.GetUserFormatValue();

--- a/Slackord/Slackord.csproj
+++ b/Slackord/Slackord.csproj
@@ -13,7 +13,7 @@
 		<ApplicationTitle>Slackord</ApplicationTitle>
 		<ApplicationId>com.thomasloupe.slackord</ApplicationId>
 		<ApplicationIdGuid>9c3974ab-37d1-4859-8f7c-aa1c453b5b00</ApplicationIdGuid>
-		<ApplicationDisplayVersion>4.0</ApplicationDisplayVersion>
+		<ApplicationDisplayVersion>4.3.2</ApplicationDisplayVersion>
 		<ApplicationVersion>4</ApplicationVersion>
 
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>


### PR DESCRIPTION
NEW - Slackord now checks for updates on startup.
NEW - Slackord now provides the patch notes for the latest version both in the update check and in the output window.
FIX - Clicking the connection button when connected wouldn't work in some cases.
FIX - Replies with no text causing an exception in thread creation.
FIX - Some cancellation token issues causing bot connection to fail.
FIX - Issue where cancelling an import required Slackord to be restarted.
CHANGE - When cancelling an import, the output window would tell you that a restart of Slackord was required. Due to the previously mentioned fix, this text was no longer true, and was removed.
CHANGE - Improved the Discord bot's connection state, text, and button interaction logic.