### PR TITLE
Fix logging and attachment handling

### DIFF
--- a/Slackord/Classes/DiscordBot.cs
+++ b/Slackord/Classes/DiscordBot.cs
@@ -789,8 +789,9 @@ namespace Slackord.Classes
                 }
             }
 
-            foreach (string localFilePath in message.FileURLs)
+            for (int i = 0; i < message.FileURLs.Count; i++)
             {
+                string localFilePath = message.FileURLs[i];
                 cancellationToken.ThrowIfCancellationRequested();
 
                 if (File.Exists(localFilePath))
@@ -825,6 +826,16 @@ namespace Slackord.Classes
                     Logger.Log($"File not found: {localFilePath}");
                     await discordChannel.SendMessageAsync($"📎 Attachment not found: {Path.GetFileName(localFilePath)}",
                         options: new RequestOptions { CancelToken = cancellationToken });
+
+                    if (i < message.FallbackFileURLs.Count)
+                    {
+                        string url = message.FallbackFileURLs[i];
+                        if (!string.IsNullOrWhiteSpace(url))
+                        {
+                            await discordChannel.SendMessageAsync(url,
+                                options: new RequestOptions { CancelToken = cancellationToken });
+                        }
+                    }
                 }
             }
         }

--- a/Slackord/Classes/ImportJson.cs
+++ b/Slackord/Classes/ImportJson.cs
@@ -279,9 +279,6 @@ namespace Slackord.Classes
         {
             try
             {
-                Application.Current.Dispatcher.Dispatch(() => {
-                    ApplicationWindow.WriteToDebugWindow($"🔨 Reconstructing for Discord...\n");
-                });
 
                 var reconstructedMessages = new List<ReconstructedMessage>();
                 int processedCount = 0;

--- a/Slackord/Classes/SlackordFileManager.cs
+++ b/Slackord/Classes/SlackordFileManager.cs
@@ -23,8 +23,6 @@ namespace Slackord.Classes
                 string json = JsonConvert.SerializeObject(messages, Formatting.Indented);
 
                 await File.WriteAllTextAsync(filePath, json, Encoding.UTF8);
-
-                ApplicationWindow.WriteToDebugWindow($"💾 Saved {messages.Count:N0} messages to {Path.GetFileName(filePath)}\n");
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
## Summary
- avoid duplicate "Reconstructing for Discord" line
- remove extra save message from file manager
- preserve slack file URLs as fallbacks and remove them when files download
- show fallback URLs in Discord if download fails