### PR TITLE
v5.2.1

### DIFF
--- a/Slackord/Classes/Version.cs
+++ b/Slackord/Classes/Version.cs
@@ -11,7 +11,7 @@
         /// <returns>The current version string</returns>
         public static string GetVersion()
         {
-            string version = "v5.2.0";
+            string version = "v5.2.1";
 
             return version;
         }

--- a/Slackord/Slackord.csproj
+++ b/Slackord/Slackord.csproj
@@ -24,8 +24,8 @@
 		<ProduceReferenceAssembly>True</ProduceReferenceAssembly>
 		<Trimming>none</Trimming>
 		<SignAssembly>False</SignAssembly>
-		<AssemblyVersion>5.2.0.0</AssemblyVersion>
-		<FileVersion>5.2.0.0</FileVersion>
+		<AssemblyVersion>5.2.1.0</AssemblyVersion>
+		<FileVersion>5.2.1.0</FileVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">


### PR DESCRIPTION
FIX - Slackdump exports weren't being properly detected causing them to be processed as standard Slack exports
FIX - Slackdump Direct Message folders being incorrectly processed as channels 
FIX - File download logic attempting to download files from URLs when Slackdump had already included them locally
FIX - RAM consumption would increase indefinitely due to failure to read Slackdump exports correctly