### PR TITLE
Improve "Getting Started" section in "README"

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,13 @@ https://github.com/user-attachments/assets/afa63789-0904-4200-8bd8-6c5dd1970355
 
 # Getting Started
 1. Download the [latest](https://github.com/thomasloupe/Slackord/releases) Slackord release and extract the contents.
-2. Create a Discord bot [here](https://discord.com/developers/applications) by selecting "New Application" at the top-right.
-3. Name your bot "Slackord", or any preferred custom name.
-4. On the "Installation" page, select "Guild Install", and select "None" for the "Install Link" and save your changes.
-5. Select "Bot" from the left panel. Ensure that both "Public Bot", and "Requires OAuth2 Code Grant" are both toggled off in Authorization Flow, and "Message Content Intent" is toggled on. then save your changes.
-6. Select "OAuth2" from the left panel. set the bot's "SCOPES" to "bot". This opens a new menu called "BOT PERMISSIONS" below. Set the bot's permissions to "Administrator".
-7. Copy the "GENERATED URL" link below the "BOT PERMISSIONS", and paste into a browser. Join the bot into your desired Discord server.
-9. Click "Reset Token", select "Yes, do it!", then click the "Copy" button to the left of "Regenerate". "Keep it secret, keep it safe."
+1. Create a Discord bot [here](https://discord.com/developers/applications) by selecting "New Application" at the top-right.
+1. Name your bot "Slackord", or any preferred custom name.
+1. On the "Installation" page, select "Guild Install", and select "None" for the "Install Link" and save your changes.
+1. Select "Bot" from the left panel. Ensure that both "Public Bot", and "Requires OAuth2 Code Grant" are both toggled off in Authorization Flow, and "Message Content Intent" is toggled on. then save your changes.
+1. Select "OAuth2" from the left panel. Set the bot's "SCOPES" to "bot". This opens a new menu called "BOT PERMISSIONS" below. Set the bot's permissions to "Administrator".
+1. Copy the "GENERATED URL" link below the "BOT PERMISSIONS", and paste into a browser. Join the bot into your desired Discord server.
+1. Select "Bot" from the left panel. Click "Reset Token", select "Yes, do it!", then click the "Copy" button to the left of "Regenerate". "Keep it secret, keep it safe."
 
 # Running Slackord
 1. Run Slackord. You may need to install the latest .NET9 framework [here](https://builds.dotnet.microsoft.com/dotnet/Runtime/9.0.5/dotnet-runtime-9.0.5-win-x64.exe).


### PR DESCRIPTION
When I was following the getting started steps, I ran into an issue: I accidentally reset the client secret instead of the bot token. The confusion happened because in step 6 the user is directed to the "OAuth2" configuration page to adjust the bot’s scopes. However, in the final step there is no mention that the "Reset Token" button is actually located under the Bot page. This PR updates the README to clarify that the Reset Token action should be performed from the "Bot" page, not the "OAuth2" page.