### PR TITLE
feat: add option to reuse existing Discord channels on import

### DIFF
--- a/Slackord/Classes/AppSettings.cs
+++ b/Slackord/Classes/AppSettings.cs
@@ -118,6 +118,8 @@
 
             CheckForUpdatesOnStartup = Preferences.Default.Get("CheckForUpdatesOnStartup", true);
 
+            SkipExistingChannels = Preferences.Default.Get("ReuseExistingChannels", false);
+
             EnableResumeImport = Preferences.Default.Get("EnableResumeImport", true);
 
             LastImportType = Preferences.Default.Get("LastImportType", string.Empty);
@@ -140,6 +142,8 @@
             Preferences.Default.Set("DiscordLogLevel", DiscordLogLevel);
 
             Preferences.Default.Set("CheckForUpdatesOnStartup", CheckForUpdatesOnStartup);
+
+            Preferences.Default.Set("ReuseExistingChannels", SkipExistingChannels);
 
             Preferences.Default.Set("LastImportType", LastImportType);
             Preferences.Default.Set("LastImportChannel", LastImportChannel);
@@ -174,6 +178,8 @@
             DiscordLogLevel = 3;
 
             CheckForUpdatesOnStartup = true;
+
+            SkipExistingChannels = false;
         }
 
         /// <summary>

--- a/Slackord/Classes/DiscordBot.cs
+++ b/Slackord/Classes/DiscordBot.cs
@@ -1219,11 +1219,21 @@ namespace Slackord.Classes
 
                     string channelName = channelProgress.Name.ToLower();
 
-                    // When reuse is enabled, look for an existing channel by name anywhere in the guild
+                    // When reuse is enabled, look for an existing channel by name in Slackord Import categories
                     if (AppSettings.Instance.SkipExistingChannels)
                     {
-                        var existingChannel = guild.TextChannels.FirstOrDefault(
-                            c => c.Name.Equals(channelName, StringComparison.OrdinalIgnoreCase));
+                        var slackordCategories = guild.CategoryChannels
+                            .Where(c => c.Name.StartsWith(baseCategoryName, StringComparison.OrdinalIgnoreCase))
+                            .Select(c => c.Id)
+                            .ToHashSet();
+
+                        var matchingChannels = guild.TextChannels
+                            .Where(c => c.Name.Equals(channelName, StringComparison.OrdinalIgnoreCase)
+                                        && c.CategoryId.HasValue
+                                        && slackordCategories.Contains(c.CategoryId.Value))
+                            .ToList();
+
+                        var existingChannel = matchingChannels.Count == 1 ? matchingChannels[0] : null;
                         if (existingChannel != null)
                         {
                             channelProgress.SetDiscordChannelId(existingChannel.Id);

--- a/Slackord/Classes/DiscordBot.cs
+++ b/Slackord/Classes/DiscordBot.cs
@@ -1219,6 +1219,25 @@ namespace Slackord.Classes
 
                     string channelName = channelProgress.Name.ToLower();
 
+                    // When reuse is enabled, look for an existing channel by name anywhere in the guild
+                    if (AppSettings.Instance.SkipExistingChannels)
+                    {
+                        var existingChannel = guild.TextChannels.FirstOrDefault(
+                            c => c.Name.Equals(channelName, StringComparison.OrdinalIgnoreCase));
+                        if (existingChannel != null)
+                        {
+                            channelProgress.SetDiscordChannelId(existingChannel.Id);
+                            CreatedChannels[existingChannel.Id] = existingChannel;
+
+                            Application.Current.Dispatcher.Dispatch(() => {
+                                ApplicationWindow.WriteToDebugWindow($"🔗 Reusing existing Discord channel: #{existingChannel.Name} (ID: {existingChannel.Id})\n");
+                            });
+
+                            await Task.Delay(100, cancellationToken);
+                            continue;
+                        }
+                    }
+
                     if (guild.TextChannels.Any(c => c.Name.Equals(channelName, StringComparison.OrdinalIgnoreCase) && c.CategoryId == currentCategoryId))
                     {
                         int suffix = 1;

--- a/Slackord/Pages/OptionsPage.xaml
+++ b/Slackord/Pages/OptionsPage.xaml
@@ -77,6 +77,13 @@
                     </Picker>
                     <Label Text="Cleanup removes import data files and channel downloads to reclaim disk space." 
                            FontSize="12" TextColor="Gray" Margin="0,5,0,0"/>
+
+                    <HorizontalStackLayout Margin="0,10,0,0">
+                        <Label Text="Reuse Existing Channels" VerticalOptions="Center" Margin="0,0,10,0"/>
+                        <Switch x:Name="ReuseExistingChannelsSwitch" IsToggled="False" VerticalOptions="Center"/>
+                    </HorizontalStackLayout>
+                    <Label Text="When enabled, Slackord will post into existing Discord channels with the same name instead of creating duplicates (e.g., #random-1). Useful for incremental imports." 
+                           FontSize="12" TextColor="Gray" Margin="0,5,0,0"/>
                 </VerticalStackLayout>
             </Border>
 

--- a/Slackord/Pages/OptionsPage.xaml.cs
+++ b/Slackord/Pages/OptionsPage.xaml.cs
@@ -162,6 +162,7 @@ namespace Slackord.Pages
             }
 
             Preferences.Default.Set("ReuseExistingChannels", ReuseExistingChannelsSwitch.IsToggled);
+            AppSettings.Instance.SkipExistingChannels = ReuseExistingChannelsSwitch.IsToggled;
 
             Preferences.Default.Set("CheckForUpdatesOnStartup", CheckUpdatesSwitch.IsToggled);
             await UpdateMainPageUISettings();

--- a/Slackord/Pages/OptionsPage.xaml.cs
+++ b/Slackord/Pages/OptionsPage.xaml.cs
@@ -69,6 +69,9 @@ namespace Slackord.Pages
 
             int cleanupBehavior = Preferences.Default.Get("CleanupAfterImport", (int)CleanupBehavior.Prompt);
             CleanupAfterImportPicker.SelectedIndex = cleanupBehavior;
+
+            bool reuseExistingChannels = Preferences.Default.Get("ReuseExistingChannels", false);
+            ReuseExistingChannelsSwitch.IsToggled = reuseExistingChannels;
         }
 
         /// <summary>
@@ -158,6 +161,8 @@ namespace Slackord.Pages
                 Preferences.Default.Set("CleanupAfterImport", CleanupAfterImportPicker.SelectedIndex);
             }
 
+            Preferences.Default.Set("ReuseExistingChannels", ReuseExistingChannelsSwitch.IsToggled);
+
             Preferences.Default.Set("CheckForUpdatesOnStartup", CheckUpdatesSwitch.IsToggled);
             await UpdateMainPageUISettings();
 
@@ -186,6 +191,7 @@ namespace Slackord.Pages
                 BotTokenEntry.Text = string.Empty;
                 LogLevelPicker.SelectedIndex = 3;
                 CleanupAfterImportPicker.SelectedIndex = (int)CleanupBehavior.Prompt;
+                ReuseExistingChannelsSwitch.IsToggled = false;
                 CheckUpdatesSwitch.IsToggled = true;
 
                 await DisplayAlertAsync("Reset Complete", "All settings have been reset to default values.", "OK");


### PR DESCRIPTION
## Summary

Adds a "Reuse Existing Channels" toggle to the Options page. When enabled, Slackord will find and post into existing Discord channels with matching names instead of creating duplicates with numbered suffixes (e.g., `#random-1`).

This enables incremental import workflows where users periodically export from Slack (e.g., using [slackdump](https://github.com/rusq/slackdump) to beat the free plan's 90-day message limit) and import new messages into the same Discord channels.

## Changes

| File | Change |
|------|--------|
| `AppSettings.cs` | Persist `SkipExistingChannels` via `Preferences.Default` (key: `ReuseExistingChannels`, default: `false`) |
| `OptionsPage.xaml` | Add Switch toggle + description in Import Settings section |
| `OptionsPage.xaml.cs` | Load/save/reset the toggle |
| `DiscordBot.cs` | In `CreateDiscordChannelsForSession`: when enabled, search all guild text channels by name before creating — reuse if found |

## Behavior

- **OFF (default)**: No change from current behavior — duplicate channels created with suffixes
- **ON**: Before creating a new channel, searches the entire guild for a text channel with the same name. If found, reuses it and skips creation.

Note: I noticed `AppSettings.cs` already had an unused `SkipExistingChannels` property — this PR wires it up.

Closes #141
